### PR TITLE
[어드민] 테스트 실패 수정하기

### DIFF
--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentsManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentsManagementControllerTest.java
@@ -34,7 +34,7 @@ class ArticleCommentsManagementControllerTest {
         mvc.perform(get("/management/article-comments"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/articleComments"));
+                .andExpect(view().name("management/article-comments"));
     }
 
 }

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
@@ -31,7 +31,7 @@ class UserAccountManagementControllerTest {
         mvc.perform(get("/management/user-accounts"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/userAccounts"));
+                .andExpect(view().name("management/user-accounts"));
     }
 
 }


### PR DESCRIPTION
강의 중 테스트를 마무리 직전에 마지막으로 실행하여 문제를 감지했어야 했는데
그러지 못했다.
댓글 관리 페이지, 회원 관리 페이지는 파일명을 일관성을 위해
캐멀케이스에서 케밥케이스로 바꿈.
이를 테스트에 반영함